### PR TITLE
Tetromino implementation

### DIFF
--- a/src/tower_struggle/common.clj
+++ b/src/tower_struggle/common.clj
@@ -1,5 +1,7 @@
 (ns tower-struggle.common
-  (:require [quip.utils :as qpu]
+  (:require [quil.core :as q]
+            [quip.utils :as qpu]
+            [quip.sprite :as qpsprite]
             [clojure.string :as s]))
 
 ;; @TODO: would be useful to add this to quip
@@ -39,7 +41,6 @@
          rgbs
          names)))
 
-
 (def orange [237 106 90])
 (def yellow [244 241 187])
 (def purple [93 87 107])
@@ -47,3 +48,40 @@
 (def white [230 235 224])
 (def grey [57 57 58])
 (def black [19 18 0])
+
+(defn draw-simple-sprite
+  "Simple box with a cross."
+  [{:keys [w h] [x y] :pos}]
+  (qpu/stroke qpu/red)
+  (qpu/fill qpu/white)
+  (q/rect x y w h)
+  (q/line [x y] [(+ x w) (+ y h)])
+  (q/line [x (+ y h)] [(+ x w) y]))
+
+;; @TODO: this should be backported into quip I've been wanting it for
+;; ages. In fact, all the default sprite functions in quip should use
+;; this merge other pattern, it's a really common use case.
+(defn simple-sprite
+  "A basic sprite for when you know you need a custom draw function."
+  [sprite-group pos &
+   {:keys [w
+           h
+           update-fn
+           draw-fn
+           bounds-fn
+           other]
+    :or {w 50
+         h 50
+         update-fn identity
+         draw-fn draw-simple-sprite
+         bounds-fn qpsprite/default-bounding-poly
+         other {}}}]
+  (merge {:sprite-group sprite-group
+          :uuid (random-uuid)
+          :pos pos
+          :w w
+          :h h
+          :update-fn update-fn
+          :draw-fn draw-fn
+          :bounds-fn bounds-fn}
+         other))

--- a/src/tower_struggle/scenes/level_01.clj
+++ b/src/tower_struggle/scenes/level_01.clj
@@ -1,13 +1,15 @@
 (ns tower-struggle.scenes.level-01
-  (:require [quip.sprite :as qpsprite]
+  (:require [quil.core :as q]
+            [quip.sprite :as qpsprite]
             [quip.utils :as qpu]
             [tower-struggle.common :as common]
-            [tower-struggle.sprites.tetromino :as t]))
+            [tower-struggle.sprites.tetromino :as t]
+            [tower-struggle.sprites.mino :as m]))
 
 (defn sprites
   "The initial list of sprites for this scene"
   []
-  [(t/tetromino [300 100])])
+  [(t/tetromino [300 900])])
 
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
@@ -18,17 +20,58 @@
 (defn transfer-locked-tetrominos
   "Move tetrominos which have just been locked in to the longer term
   storage"
-  [state]
-  ;; @TODO: implement me
-  state)
+  [{:keys [current-scene] :as state}]
+  (let [sprites (get-in state [:scenes current-scene :sprites])
+        tetrominos (filter (qpsprite/group-pred :tetromino) sprites)
+        others (remove (qpsprite/group-pred :tetromino) sprites)
+        locked (filter :locked? tetrominos)
+        unlocked (remove :locked? tetrominos)]
+    (assoc-in state [:scenes current-scene :sprites]
+              (concat others
+                      unlocked
+                      (when (seq locked)
+                        (-> locked
+                            t/all-minos
+                            m/create-multiple))))))
+
+(defn lock-tetrominos
+  "Find any tetrominos which have _just_ about to move and are sitting
+  on top of a locked mino, lock them down."
+  [{:keys [current-scene] :as state}]
+  (let [sprites (get-in state [:scenes current-scene :sprites])
+        locked-minos (filter (qpsprite/group-pred :mino) sprites)]
+    (qpsprite/update-sprites-by-pred
+     state
+     (fn [s]
+       (and (= :tetromino (:sprite-group s))
+            (= 1 (:fall-delay s))  ; will move next frame
+            (let [{:keys [pos w h current-rotation rotations]} s
+                  [x y] pos
+                  minos (get rotations current-rotation)]
+              (some (fn my-minos [[m [dx dy]]]
+                      ;; the `(inc dy)` here is because we are interested in
+                      ;; the _bottom_ edge of the mino
+                      (or (<= (q/height) (+ y (* h (inc dy))))
+                          ;; check if other previously locked minos beneath
+                          (some (fn their-minos [{locked-pos :pos}]
+                                  (= [(+ x (* w dx))
+                                      (+ y (* h (inc dy)))]
+                                     locked-pos))
+                                locked-minos)))
+                    minos))))
+     (fn [s]
+       (assoc s :locked? true)))))
 
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
       qpsprite/update-scene-sprites
+      lock-tetrominos
       transfer-locked-tetrominos))
 
+;; @TODO: these left/right functions need to take into account locked
+;; minos so we don't move into them.
 (defn handle-left
   [{:keys [current-scene] :as state}]
   (qpsprite/update-sprites-by-pred
@@ -48,13 +91,20 @@
   (prn "space")
   state)
 
+(defn handle-enter
+  [{:keys [current-scene] :as state}]
+  (update-in state [:scenes current-scene :sprites] conj (t/tetromino [300 100])))
+
 (defn handle-key-pressed
   [state e]
   (let [handlers {:left handle-left
                   :right handle-right
-                  :space handle-space}
-        k (:key e)]
-    (if-let [handler (handlers k)]
+                  :space handle-space
+                  10 handle-enter}
+        k (:key e)
+        kc (:key-code e)]
+    (if-let [handler (or (handlers k)
+                         (handlers kc))]
       (handler state)
       state)))
 

--- a/src/tower_struggle/scenes/level_01.clj
+++ b/src/tower_struggle/scenes/level_01.clj
@@ -70,21 +70,33 @@
       lock-tetrominos
       transfer-locked-tetrominos))
 
-;; @TODO: these left/right functions need to take into account locked
-;; minos so we don't move into them.
 (defn handle-left
   [{:keys [current-scene] :as state}]
   (qpsprite/update-sprites-by-pred
    state
    (qpsprite/group-pred :tetromino)
-   t/move-left))
+   (partial t/move-left state)))
 
 (defn handle-right
   [{:keys [current-scene] :as state}]
   (qpsprite/update-sprites-by-pred
    state
    (qpsprite/group-pred :tetromino)
-   t/move-right))
+   (partial t/move-right state)))
+
+(defn handle-up
+  [{:keys [current-scene] :as state}]
+  (qpsprite/update-sprites-by-pred
+   state
+   (qpsprite/group-pred :tetromino)
+   (partial t/rotate-clockwise state)))
+
+(defn handle-down
+  [{:keys [current-scene] :as state}]
+  (qpsprite/update-sprites-by-pred
+   state
+   (qpsprite/group-pred :tetromino)
+   (partial t/rotate-anticlockwise state)))
 
 (defn handle-space
   [{:keys [current-scene] :as state}]
@@ -99,6 +111,8 @@
   [state e]
   (let [handlers {:left handle-left
                   :right handle-right
+                  :up handle-up
+                  :down handle-down
                   :space handle-space
                   10 handle-enter}
         k (:key e)

--- a/src/tower_struggle/scenes/level_01.clj
+++ b/src/tower_struggle/scenes/level_01.clj
@@ -1,12 +1,13 @@
 (ns tower-struggle.scenes.level-01
   (:require [quip.sprite :as qpsprite]
             [quip.utils :as qpu]
-            [tower-struggle.common :as common]))
+            [tower-struggle.common :as common]
+            [tower-struggle.sprites.tetromino :as t]))
 
 (defn sprites
   "The initial list of sprites for this scene"
   []
-  [])
+  [(t/tetromino [300 100])])
 
 (defn draw-level-01
   "Called each frame, draws the current scene to the screen"
@@ -14,15 +15,53 @@
   (qpu/background common/blue)
   (qpsprite/draw-scene-sprites state))
 
+(defn transfer-locked-tetrominos
+  "Move tetrominos which have just been locked in to the longer term
+  storage"
+  [state]
+  ;; @TODO: implement me
+  state)
+
 (defn update-level-01
   "Called each frame, update the sprites in the current scene"
   [state]
   (-> state
-      qpsprite/update-scene-sprites))
+      qpsprite/update-scene-sprites
+      transfer-locked-tetrominos))
+
+(defn handle-left
+  [{:keys [current-scene] :as state}]
+  (qpsprite/update-sprites-by-pred
+   state
+   (qpsprite/group-pred :tetromino)
+   t/move-left))
+
+(defn handle-right
+  [{:keys [current-scene] :as state}]
+  (qpsprite/update-sprites-by-pred
+   state
+   (qpsprite/group-pred :tetromino)
+   t/move-right))
+
+(defn handle-space
+  [{:keys [current-scene] :as state}]
+  (prn "space")
+  state)
+
+(defn handle-key-pressed
+  [state e]
+  (let [handlers {:left handle-left
+                  :right handle-right
+                  :space handle-space}
+        k (:key e)]
+    (if-let [handler (handlers k)]
+      (handler state)
+      state)))
 
 (defn init
   "Initialise this scene"
   []
   {:sprites (sprites)
    :draw-fn draw-level-01
-   :update-fn update-level-01})
+   :update-fn update-level-01
+   :key-pressed-fns [handle-key-pressed]})

--- a/src/tower_struggle/scenes/menu.clj
+++ b/src/tower_struggle/scenes/menu.clj
@@ -100,7 +100,7 @@
     (fn [{:keys [current-scene] :as state}]
       (-> state
           (update-in [:scenes current-scene :sprites] conj (square))
-          (qpdelay/add-delay (box-delay))))))
+          (qpdelay/add-delay (add-square-delay))))))
 
 (defn init
   "Initialise this scene"
@@ -108,7 +108,6 @@
   {:sprites (sprites)
    :draw-fn draw-menu
    :update-fn update-menu
-   :mouse-pressed-fns [qpbutton/handle-buttons-pressed
-                       box]
+   :mouse-pressed-fns [qpbutton/handle-buttons-pressed]
    :mouse-released-fns [qpbutton/handle-buttons-released]
    :delays [(add-square-delay)]})

--- a/src/tower_struggle/sprites/mino.clj
+++ b/src/tower_struggle/sprites/mino.clj
@@ -1,0 +1,34 @@
+(ns tower-struggle.sprites.mino
+  "Once the tetrominos have been locked in, we transform them into
+  individual minos so we can more easily detect collisions and
+  calculate adjacency effects."
+  (:require [quil.core :as q]
+            [quip.utils :as qpu]
+            [tower-struggle.common :as common]))
+
+(defn draw-mino
+  [{:keys [pos w h room] :as mino}]
+  (let [[x y] pos]
+    (case room
+      :resi (qpu/fill (nth (iterate qpu/darken common/purple) 2))
+      :comm (qpu/fill (nth (iterate qpu/darken common/yellow) 2))
+      :util (qpu/fill (nth (iterate qpu/darken common/orange) 2)))
+    (q/no-stroke)
+    (q/rect x y w h)))
+
+(defn mino
+  [pos room size]
+  (common/simple-sprite
+   :mino
+   pos
+   :w size
+   :h size
+   :draw-fn draw-mino
+   :update-fn identity
+   :other {:room room
+           :locked? true}))
+
+(defn create-multiple
+  [param-lists]
+  (map (partial apply mino)
+       param-lists))

--- a/src/tower_struggle/sprites/tetromino.clj
+++ b/src/tower_struggle/sprites/tetromino.clj
@@ -152,7 +152,7 @@
             :locked? false})))
 
 (defn allowed-location?
-  [{:keys [pos w h current-rotation rotations] :as t} {:keys [current-scene] :as state}]
+  [{:keys [current-scene] :as state} {:keys [pos w h current-rotation rotations] :as t}]
   (let [[x y] pos
         sprites (get-in state [:scenes current-scene :sprites])
         locked-minos (filter (qpsprite/group-pred :mino) sprites)
@@ -164,7 +164,7 @@
                   ;; right boundary
                   (<= (q/width) (+ x (* w dx)))
                   ;; bottom boundary
-                  (<= (q/height) (+ y (* h (inc dy))))
+                  (<= (q/height) (+ y (* h dy)))
                   ;; check other previously locked minos
                   (some (fn their-minos [{locked-pos :pos}]
                           (= [(+ x (* w dx))
@@ -178,7 +178,7 @@
   (if locked?
     t
     (let [updated-t (update-in t [:pos 0] - (:w t))]
-      (if (allowed-location? updated-t state)
+      (if (allowed-location? state updated-t)
         updated-t
         t))))
 
@@ -187,7 +187,7 @@
   (if locked?
     t
     (let [updated-t (update-in t [:pos 0] + (:w t))]
-      (if (allowed-location? updated-t state)
+      (if (allowed-location? state updated-t)
         updated-t
         t))))
 
@@ -196,7 +196,7 @@
   (if locked?
     t
     (let [updated-t (update t :current-rotation (fn [n] (mod (inc n) 4)))]
-      (if (allowed-location? updated-t state)
+      (if (allowed-location? state updated-t)
         updated-t
         t))))
 
@@ -205,7 +205,7 @@
   (if locked?
     t
     (let [updated-t (update t :current-rotation (fn [n] (mod (dec n) 4)))]
-      (if (allowed-location? updated-t state)
+      (if (allowed-location? state updated-t)
         updated-t
         t))))
 

--- a/src/tower_struggle/sprites/tetromino.clj
+++ b/src/tower_struggle/sprites/tetromino.clj
@@ -1,0 +1,179 @@
+(ns tower-struggle.sprites.tetromino
+  "Standard names for Tetrominos are I, O, T, S, Z, J, L.
+
+  We're describing each rotation of a tetromino by listing the
+  relative coordinates of it's minos (squares) as they appear in the
+  4x4 grids shown in the comments above each definition.
+
+  The minos are labelled a-d since they can contain different kinds of
+  room, this means we need to keep track of where each mino goes
+  between rotations.
+
+  @NOTE: the grids are 8x4, but this is to compensate for the 1x2
+  monospace character height."
+  (:require [quil.core :as q]
+            [quip.sprite :as qpsprite]
+            [quip.utils :as qpu]
+            [tower-struggle.common :as common]))
+
+;; ░░░░░░░░  ░░░░██░░  ░░░░░░░░  ░░██░░░░
+;; ████████  ░░░░██░░  ░░░░░░░░  ░░██░░░░
+;; ░░░░░░░░  ░░░░██░░  ████████  ░░██░░░░
+;; ░░░░░░░░  ░░░░██░░  ░░░░░░░░  ░░██░░░░
+(def i-rotations
+  [{:a [0 1] :b [1 1] :c [2 1] :d [3 1]}
+   {:a [2 0] :b [2 1] :c [2 2] :d [2 3]}
+   {:a [3 2] :b [2 2] :c [1 2] :d [0 2]}
+   {:a [1 3] :b [1 2] :c [1 1] :d [1 0]}])
+
+;; ░░████░░  ░░████░░  ░░████░░  ░░████░░
+;; ░░████░░  ░░████░░  ░░████░░  ░░████░░
+;; ░░░░░░░░  ░░░░░░░░  ░░░░░░░░  ░░░░░░░░
+;; ░░░░░░░░  ░░░░░░░░  ░░░░░░░░  ░░░░░░░░
+(def o-rotations
+  [{:a [1 0] :b [2 0] :c [2 1] :d [1 1]}
+   {:a [2 0] :b [2 1] :c [1 1] :d [1 0]}
+   {:a [2 1] :b [1 1] :c [1 0] :d [2 0]}
+   {:a [1 1] :b [1 0] :c [2 0] :d [2 1]}])
+
+;; ░░██░░░░  ░░██░░░░  ░░░░░░░░  ░░██░░░░
+;; ██████░░  ░░████░░  ██████░░  ████░░░░
+;; ░░░░░░░░  ░░██░░░░  ░░██░░░░  ░░██░░░░
+;; ░░░░░░░░  ░░░░░░░░  ░░░░░░░░  ░░░░░░░░
+(def t-rotations
+  [{:a [1 0] :b [0 1] :c [1 1] :d [2 1]}
+   {:a [2 1] :b [1 0] :c [1 1] :d [1 2]}
+   {:a [1 2] :b [2 1] :c [1 1] :d [0 1]}
+   {:a [0 1] :b [1 2] :c [1 1] :d [1 0]}])
+
+;; ░░████░░  ░░██░░░░  ░░░░░░░░  ██░░░░░░
+;; ████░░░░  ░░████░░  ░░████░░  ████░░░░
+;; ░░░░░░░░  ░░░░██░░  ████░░░░  ░░██░░░░
+;; ░░░░░░░░  ░░░░░░░░  ░░░░░░░░  ░░░░░░░░
+(def s-rotations
+  [{:a [1 0] :b [2 0] :c [0 1] :d [1 1]}
+   {:a [2 1] :b [2 2] :c [1 0] :d [1 1]}
+   {:a [1 2] :b [0 2] :c [2 1] :d [1 1]}
+   {:a [0 1] :b [0 0] :c [1 2] :d [1 1]}])
+
+;; ████░░░░  ░░░░██░░  ░░░░░░░░  ░░██░░░░
+;; ░░████░░  ░░████░░  ████░░░░  ████░░░░
+;; ░░░░░░░░  ░░██░░░░  ░░████░░  ██░░░░░░
+;; ░░░░░░░░  ░░░░░░░░  ░░░░░░░░  ░░░░░░░░
+(def z-rotations
+  [{:a [0 0] :b [1 0] :c [1 1] :d [2 1]}
+   {:a [2 0] :b [2 1] :c [1 1] :d [1 2]}
+   {:a [2 2] :b [1 2] :c [1 1] :d [0 1]}
+   {:a [0 2] :b [0 1] :c [1 1] :d [1 0]}])
+
+;; ██░░░░░░  ░░████░░  ░░░░░░░░  ░░██░░░░
+;; ██████░░  ░░██░░░░  ██████░░  ░░██░░░░
+;; ░░░░░░░░  ░░██░░░░  ░░░░██░░  ████░░░░
+;; ░░░░░░░░  ░░░░░░░░  ░░░░░░░░  ░░░░░░░░
+(def j-rotations
+  [{:a [0 0] :b [0 1] :c [1 1] :d [2 1]}
+   {:a [2 0] :b [1 0] :c [1 1] :d [1 2]}
+   {:a [2 2] :b [2 1] :c [1 1] :d [0 1]}
+   {:a [0 2] :b [1 2] :c [1 1] :d [1 0]}])
+
+;; ░░░░██░░  ░░██░░░░  ░░░░░░░░  ████░░░░
+;; ██████░░  ░░██░░░░  ██████░░  ░░██░░░░
+;; ░░░░░░░░  ░░████░░  ██░░░░░░  ░░██░░░░
+;; ░░░░░░░░  ░░░░░░░░  ░░░░░░░░  ░░░░░░░░
+(def l-rotations
+  [{:a [2 0] :b [0 1] :c [1 1] :d [2 1]}
+   {:a [2 2] :b [1 0] :c [1 1] :d [1 2]}
+   {:a [0 2] :b [2 1] :c [1 1] :d [0 1]}
+   {:a [0 0] :b [1 2] :c [1 1] :d [1 0]}])
+
+(def piece-rotations
+  {:i i-rotations
+   :o o-rotations
+   :t t-rotations
+   :s s-rotations
+   :z z-rotations
+   :j j-rotations
+   :l l-rotations})
+
+(def room-types [:resi :comm :util])
+
+;; @TODO: could bias towards certain rooms types?
+(defn random-rooms
+  []
+  (zipmap [:a :b :c :d]
+          (repeatedly #(rand-nth room-types))))
+
+(defn draw-tetromino
+  [{:keys [pos w h current-rotation rotations rooms] :as tetromino}]
+  (let [[x y] pos
+        minos (get rotations current-rotation)]
+    (doseq [[m [dx dy]] minos]
+      (let [room (get rooms m)]
+        (case room
+          :resi (qpu/fill common/purple)
+          :comm (qpu/fill common/yellow)
+          :util (qpu/fill common/orange))
+        (q/no-stroke)
+        (q/rect (+ x (* w dx))
+                (+ y (* h dy))
+                w
+                h)))))
+
+(def initial-fall-delay 40)
+(def mino-size 50)
+
+(defn update-locked
+  [{:keys [pos w h current-rotation rotations] :as t}]
+  (let [[x y] pos
+        minos (get rotations current-rotation)]
+    (if (some (fn [[m [dx dy]]]
+                ;; the `(inc dy)` here is because we are interested in
+                ;; the _bottom_ edge of the mino
+                (or (<= (q/height) (+ y (* h (inc dy))))
+                    ;; also check if other previously locked minos beneath
+                    ))
+              minos)
+      (assoc t :locked? true)
+      t)))
+
+(defn update-tetromino
+  [{:keys [w h fall-delay locked?] :as t}]
+  (if locked?
+    t
+    (if (zero? fall-delay)
+      (-> t
+          (assoc :fall-delay initial-fall-delay)
+          (update-in [:pos 1] + h)
+          update-locked)
+      (-> t
+          (update :fall-delay dec)))))
+
+(defn tetromino
+  ([pos]
+   (tetromino pos (rand-nth (keys piece-rotations))))
+  ([pos piece]
+   (common/simple-sprite
+    :tetromino
+    pos
+    :w mino-size
+    :h mino-size
+    :draw-fn draw-tetromino
+    :update-fn update-tetromino
+    :other {:piece piece
+            :rotations (get piece-rotations piece)
+            :current-rotation 0
+            :rooms (random-rooms)
+            :fall-delay initial-fall-delay
+            :locked? false})))
+
+(defn move-left
+  [{:keys [locked? pos] :as t}]
+  (if locked?
+    t
+    (update-in t [:pos 0] - mino-size)))
+
+(defn move-right
+  [{:keys [locked? pos] :as t}]
+  (if locked?
+    t
+    (update-in t [:pos 0] + mino-size)))


### PR DESCRIPTION
This is the beginning of the tetromino implementation, at a point that's it's probably worth merging in.

We have definitions for the different pieces and how they rotate, we have controllable sprites which lock themselves in place when the get to the bottom of the screen or when they land on already locked tetrominos.

You can ceate a new tetromino by pressing enter.

The pattern for determining if you can move/rotate in a certain direction is to create an update verison of the tetromino where is had been moved/rotated, and then call the `allowed-location?` function passing that tetromino in.

TODO:
- sync up the movement of newly created tetrominos