### PR TITLE
Improve tetromino gameplay

### DIFF
--- a/src/tower_struggle/sprites/mino.clj
+++ b/src/tower_struggle/sprites/mino.clj
@@ -10,9 +10,9 @@
   [{:keys [pos w h room] :as mino}]
   (let [[x y] pos]
     (case room
-      :resi (qpu/fill (nth (iterate qpu/darken common/purple) 2))
-      :comm (qpu/fill (nth (iterate qpu/darken common/yellow) 2))
-      :util (qpu/fill (nth (iterate qpu/darken common/orange) 2)))
+      :resi (qpu/fill (qpu/darken common/purple))
+      :comm (qpu/fill (qpu/darken common/yellow))
+      :util (qpu/fill (qpu/darken common/orange)))
     (q/no-stroke)
     (q/rect x y w h)))
 
@@ -25,8 +25,7 @@
    :h size
    :draw-fn draw-mino
    :update-fn identity
-   :other {:room room
-           :locked? true}))
+   :other {:room room}))
 
 (defn create-multiple
   [param-lists]

--- a/src/tower_struggle/sprites/tetromino.clj
+++ b/src/tower_struggle/sprites/tetromino.clj
@@ -119,16 +119,17 @@
                 w
                 h)))))
 
-(def initial-fall-delay 40)
+(def default-max-fall-delay 40)
+(def fast-max-fall-delay 2)
 (def mino-size 50)
 
 (defn update-tetromino
-  [{:keys [w h fall-delay locked?] :as t}]
+  [{:keys [w h fall-delay max-fall-delay locked?] :as t}]
   (if locked?
     t
     (if (zero? fall-delay)
       (-> t
-          (assoc :fall-delay initial-fall-delay)
+          (assoc :fall-delay max-fall-delay)
           (update-in [:pos 1] + h))
       (-> t
           (update :fall-delay dec)))))
@@ -148,7 +149,8 @@
             :rotations (get piece-rotations piece)
             :current-rotation 0
             :rooms (random-rooms)
-            :fall-delay initial-fall-delay
+            :fall-delay default-max-fall-delay
+            :max-fall-delay default-max-fall-delay
             :locked? false})))
 
 (defn allowed-location?
@@ -208,6 +210,22 @@
       (if (allowed-location? state updated-t)
         updated-t
         t))))
+
+(defn fast-speed
+  [{:keys [max-fall-delay] :as t}]
+  (if (= max-fall-delay default-max-fall-delay)
+    (-> t
+        (assoc :max-fall-delay fast-max-fall-delay)
+        (assoc :fall-delay fast-max-fall-delay))
+    t))
+
+(defn default-speed
+  [{:keys [max-fall-delay] :as t}]
+  (if (= max-fall-delay fast-max-fall-delay)
+    (-> t
+        (assoc :max-fall-delay default-max-fall-delay)
+        (assoc :fall-delay default-max-fall-delay))
+    t))
 
 (defn all-minos
   [ts]


### PR DESCRIPTION
Add the ability to hold space to zip currently active tetrominos to the bottom, also make new tetrominos when old ones lock in as a temporary testing feature.

Also added a game reset when you hit the `r` key for now.